### PR TITLE
Fix an error when the user adds a new environmental variable

### DIFF
--- a/windows/source/frmAddEnvironmentVariableU.pas
+++ b/windows/source/frmAddEnvironmentVariableU.pas
@@ -50,13 +50,13 @@ var
   LAllow: Boolean;
 begin
   LAllow := True;
-  if Trim(editName.Text) <> '' then
+  if Trim(editName.Text) = '' then
   begin
     MessageDlg('Please specify a valid name.', mtError, [mbOK], 0);
     LAllow := False;
   end;
 
-  if Trim(editValue.Text) <> '' then
+  if Trim(editValue.Text) = '' then
   begin
     MessageDlg('Please specify a valid value.', mtError, [mbOK], 0);
     LAllow := False;


### PR DESCRIPTION
When the user was adding a new environmental variable, the app was complaining that the non-empty values were wrong